### PR TITLE
fix(osxkeychain): fix nil pointer dereference when keychain entry not found

### DIFF
--- a/helper/osxkeychain/osxkeychain_darwin.go
+++ b/helper/osxkeychain/osxkeychain_darwin.go
@@ -96,7 +96,7 @@ func (h Osxkeychain) Get(serverURL string) (string, string, error) {
 	if err != nil {
 		switch err.Error() {
 		case errCredentialsNotFound:
-			logger.WithField("goMsg", err.Error()).Debug("Get credentials")
+			logger.Debug("Get credentials: empty result")
 			return "", "", credentials.ErrCredentialsNotFound
 		case errInteractionNotAllowed:
 			return "", "", ErrInteractionNotAllowed
@@ -105,7 +105,7 @@ func (h Osxkeychain) Get(serverURL string) (string, string, error) {
 			return "", "", err
 		}
 	} else if len(res) == 0 {
-		logger.WithField("goMsg", err.Error()).Debug("Get credentials")
+		logger.Debug("Get credentials: empty result")
 		return "", "", credentials.ErrCredentialsNotFound
 	}
 


### PR DESCRIPTION
## Problem

When no keychain entry exists for the account (e.g. on a fresh installation or after clearing credentials), `saml2alibabacloud login` panics:
```
panic: runtime error: invalid memory address or nil pointer dereference
goroutine 1 [running]:
github.com/aliyun/saml2alibabacloud/helper/osxkeychain.Osxkeychain.Get(...)
helper/osxkeychain/osxkeychain_darwin.go:108
```
## Root Cause

In `osxkeychain_darwin.go`, when the keychain search returns an empty result (`len(res) == 0`), `err` is `nil`. The code was calling `err.Error()` in this branch, which causes a nil pointer dereference.

## Fix

Replace `logger.WithField("goMsg", err.Error())` with a static log message in the empty result branch, since `err` is guaranteed to be `nil` there.

## How to Reproduce

```bash
# Clear keychain entry
security delete-internet-password -a "your@email.com" -s "sso.yourprovider.com" -p "/saml2/your-app"

# Panics without the fix
saml2alibabacloud login -a your-account
```

## Workaround

Running `saml2alibabacloud configure -a your-account` before `login` creates the keychain entry and avoids the panic.

## Fix

See PR #23 