### PR TITLE
﻿fix(exec): use sts_endpoint from config with explicit HTTPS scheme

### DIFF
--- a/cmd/saml2alibabacloud/commands/console.go
+++ b/cmd/saml2alibabacloud/commands/console.go
@@ -53,7 +53,7 @@ func Console(consoleFlags *flags.ConsoleFlags) error {
 
 	if consoleFlags.LoginExecFlags.ExecProfile != "" {
 		// Assume the desired role before generating env vars
-		alibabacloudCreds, err = assumeRoleWithProfile(alibabacloudCreds, consoleFlags.LoginExecFlags.ExecProfile, consoleFlags.LoginExecFlags.CommonFlags.SessionDuration)
+		alibabacloudCreds, err = assumeRoleWithProfile(alibabacloudCreds, account, consoleFlags.LoginExecFlags.ExecProfile, consoleFlags.LoginExecFlags.CommonFlags.SessionDuration)
 		if err != nil {
 			return errors.Wrap(err,
 				fmt.Sprintf("error acquiring credentials for profile: %s", consoleFlags.LoginExecFlags.ExecProfile))
@@ -82,7 +82,7 @@ func loadOrLogin(account *cfg.IDPAccount, sharedCreds *alibabacloudconfig.Creden
 		return loginRefreshCredentials(sharedCreds, execFlags.LoginExecFlags)
 	}
 
-	ok, err := checkToken(alibabacloudCreds)
+	ok, err := checkToken(alibabacloudCreds, account)
 	if err != nil {
 		return nil, errors.Wrap(err, "error validating token")
 	}

--- a/cmd/saml2alibabacloud/commands/exec.go
+++ b/cmd/saml2alibabacloud/commands/exec.go
@@ -2,12 +2,14 @@ package commands
 
 import (
 	"fmt"
+	"strings"
 	"log"
 
 	sdkError "github.com/aliyun/alibaba-cloud-sdk-go/sdk/errors"
 	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/requests"
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/sts"
 	"github.com/aliyun/saml2alibabacloud/pkg/alibabacloudconfig"
+	"github.com/aliyun/saml2alibabacloud/pkg/cfg"
 	"github.com/aliyun/saml2alibabacloud/pkg/flags"
 	"github.com/aliyun/saml2alibabacloud/pkg/shell"
 	"github.com/pkg/errors"
@@ -44,7 +46,7 @@ func Exec(execFlags *flags.LoginExecFlags, cmdline []string) error {
 		return errors.Wrap(err, "error loading credentials")
 	}
 
-	ok, err := checkToken(alibabacloudCreds)
+	ok, err := checkToken(alibabacloudCreds, account)
 	if err != nil {
 		return errors.Wrap(err, "error validating token")
 	}
@@ -58,7 +60,7 @@ func Exec(execFlags *flags.LoginExecFlags, cmdline []string) error {
 
 	if execFlags.ExecProfile != "" {
 		// Assume the desired role before generating env vars
-		alibabacloudCreds, err = assumeRoleWithProfile(alibabacloudCreds, execFlags.ExecProfile, execFlags.CommonFlags.SessionDuration)
+		alibabacloudCreds, err = assumeRoleWithProfile(alibabacloudCreds, account, execFlags.ExecProfile, execFlags.CommonFlags.SessionDuration)
 		if err != nil {
 			return errors.Wrap(err,
 				fmt.Sprintf("error acquiring credentials for profile: %s", execFlags.ExecProfile))
@@ -71,7 +73,7 @@ func Exec(execFlags *flags.LoginExecFlags, cmdline []string) error {
 // assumeRoleWithProfile uses an AlibabaCloud CLI profile (via ~/.aliyun/config.json) and performs (multiple levels of) role assumption
 // This is extremely useful in the case of a central "authentication account" which then requires secondary, and
 // often tertiary, role assumptions to acquire credentials for the target role.
-func assumeRoleWithProfile(alibabacloudCreds *alibabacloudconfig.AliCloudCredentials, targetProfile string, sessionDuration int) (*alibabacloudconfig.AliCloudCredentials, error) {
+func assumeRoleWithProfile(alibabacloudCreds *alibabacloudconfig.AliCloudCredentials, account *cfg.IDPAccount, targetProfile string, sessionDuration int) (*alibabacloudconfig.AliCloudCredentials, error) {
 
 	// get target profile
 	sharedCreds := alibabacloudconfig.NewSharedCredentials(targetProfile)
@@ -98,6 +100,8 @@ func assumeRoleWithProfile(alibabacloudCreds *alibabacloudconfig.AliCloudCredent
 	if err != nil {
 		return nil, err
 	}
+	client.Domain = strings.TrimPrefix(strings.TrimPrefix(account.STSEndpoint, "https://"), "http://")
+	client.GetConfig().Scheme = "HTTPS"
 	client.AppendUserAgent("saml2alibabacloud", "0.0.6")
 	request := sts.CreateAssumeRoleRequest()
 	request.RoleSessionName = targetCreds.AliCloudSessionToken
@@ -119,13 +123,15 @@ func assumeRoleWithProfile(alibabacloudCreds *alibabacloudconfig.AliCloudCredent
 	}, nil
 }
 
-func checkToken(alibabacloudCreds *alibabacloudconfig.AliCloudCredentials) (bool, error) {
+func checkToken(alibabacloudCreds *alibabacloudconfig.AliCloudCredentials, account *cfg.IDPAccount) (bool, error) {
 	client, err := sts.NewClientWithStsToken("cn-hangzhou", alibabacloudCreds.AliCloudAccessKey, alibabacloudCreds.AliCloudSecretKey, alibabacloudCreds.AliCloudSecurityToken)
 
 	if err != nil {
 		return false, err
 	}
 
+	client.Domain = strings.TrimPrefix(strings.TrimPrefix(account.STSEndpoint, "https://"), "http://")
+	client.GetConfig().Scheme = "HTTPS"
 	client.AppendUserAgent("saml2alibabacloud", "0.0.6")
 
 	request := sts.CreateGetCallerIdentityRequest()

--- a/pkg/cfg/cfg.go
+++ b/pkg/cfg/cfg.go
@@ -45,6 +45,7 @@ type IDPAccount struct {
 	Subdomain             string `ini:"subdomain"`   // used by OneLogin
 	RoleARN               string `ini:"role_arn"`
 	Region                string `ini:"region"`
+	STSEndpoint           string `ini:"sts_endpoint"`
 	HTTPAttemptsCount     string `ini:"http_attempts_count"`
 	HTTPRetryDelay        string `ini:"http_retry_delay"`
 	BrowserType           string `ini:"browser_type,omitempty"`            // used by 'Browser' Provider


### PR DESCRIPTION
## Problem

When running `saml2alibabacloud exec`, the STS token validation fails with:
```
error validating token: SDK.ServerError
ErrorCode: InvalidProtocol.NeedSsl
Message: Your request is denied as lack of ssl protect.
```

## Root Cause

Two issues were found:

1. The Alibaba Cloud SDK defaults to HTTP for STS requests. Neither `checkToken` nor `assumeRoleWithProfile` explicitly set the HTTPS scheme.
2. The `sts_endpoint` field from `~/.saml2alibabacloud` was not defined in the `IDPAccount` struct and was never read or used — meaning any custom STS endpoint configured by the user was silently ignored.

## Fix

- Add `STSEndpoint` field to `IDPAccount` struct (`ini:"sts_endpoint"`)
- Pass `account` into `checkToken` and `assumeRoleWithProfile`
- Use `account.STSEndpoint` as `client.Domain`, stripping the URL scheme since the SDK constructs the full URL itself
- Explicitly set HTTPS scheme on the STS client

## How to Reproduce

```bash
saml2alibabacloud -a your-account exec -- env
# error validating token: SDK.ServerError
# ErrorCode: InvalidProtocol.NeedSsl
```

## Testing

After the fix:

```bash
saml2alibabacloud -a your-account exec -- ansible-inventory -i your-inventory --graph
# works correctly
```

Fixes #24 